### PR TITLE
Adciona pesquisa de estados por nome ou codigo

### DIFF
--- a/lib/sql.rb
+++ b/lib/sql.rb
@@ -12,6 +12,10 @@ class Sql
   def self.search_mu(codigo)
     new(codigo).mu_populate
   end
+
+  def self.total_population(codigo)
+    new(codigo).sum_population
+  end
   
   def initialize(codigo)
     @codigo = codigo
@@ -19,7 +23,7 @@ class Sql
   end
 
   def search
-   @db.execute "SELECT title FROM UF WHERE code LIKE'#{@codigo}'"
+   @db.execute "SELECT code FROM UF WHERE title='#{@codigo}' OR code='#{@codigo}'"
   end
   
   def populate
@@ -29,4 +33,9 @@ class Sql
   def mu_populate
     @db.execute "SELECT habitants FROM MU WHERE title='#{@codigo}' OR code='#{@codigo}'"
   end
+
+  def sum_population
+    @db.execute "SELECT SUM(habitants) FROM MU WHERE code LIKE '#{search.first.first}%'"
+  end
+
 end

--- a/spec/censo_spec.rb
+++ b/spec/censo_spec.rb
@@ -4,10 +4,16 @@ require 'sqlite3'
 describe Sql do
   db = SQLite3::Database.open "db/database.db"
   
-  it 'Encortar um estado pelo codigo' do
+  it 'Deveria encortar o codigo de um estado pelo nome' do
+    uf = 'São Paulo'
+    resultado = Sql.search_uf(uf)
+    expect(resultado.first).to include(35)
+  end
+
+  it 'Deveria encortar o codigo de um estado pelo codigo' do
     uf = '35'
     resultado = Sql.search_uf(uf)
-    expect(resultado.first).to include('São Paulo')
+    expect(resultado.first).to include(35)
   end
 
   it 'Listar os 10 municipios mais populosos de um estado' do
@@ -29,6 +35,18 @@ describe Sql do
     mu = '3550308'
     resultado = Sql.search_mu(mu)
     expect(resultado.first).to include(12252023)
+  end
+
+  it 'Deveria informar a populacao total de uma UF buscando pelo codigo' do
+    uf = '35'
+    resultado = Sql.total_population(uf)
+    expect(resultado.first).to include(45919049)
+  end
+
+  it 'Deveria informar a populacao total de uma UF buscando pelo nome' do
+    uf = 'São Paulo'
+    resultado = Sql.total_population(uf)
+    expect(resultado.first).to include(45919049)
   end
 
 end


### PR DESCRIPTION
<h1>Motivação</h1>
Permitir que o usuário pesquise uma UF pelo nome, ou pelo seu código.

<h1>Solução</h1>
Criada uma query que busca as UF pelo código, ou pelo nome. Essa query retorna o código da UF independente se for passado um código ou titulo para a busca, assim, com o seu código é possível encontrar todas os municípios dessa UF e somar a sua população para obter a população total de um estado.